### PR TITLE
Improvements for PHPUnit assertion and fixtues

### DIFF
--- a/tests/MiscTest.php
+++ b/tests/MiscTest.php
@@ -16,7 +16,7 @@ class MiscTest extends TestCase
 
     private array $flows = [];
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $dirs = scandir(self::CASE_DIR);
 

--- a/tests/ProtosTest.php
+++ b/tests/ProtosTest.php
@@ -489,7 +489,7 @@ class ProtosTest extends TestCase
 
     private array $flows = [];
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         if (!is_dir(self::CASE_DIR)) {
             mkdir(self::CASE_DIR, 0777);

--- a/tests/StreamParserTest.php
+++ b/tests/StreamParserTest.php
@@ -66,7 +66,7 @@ class StreamParserTest extends TestCase
 
         if ($this->parser->process($bytes, $messages) === StreamParser::SUCCESS) {
             /* Expect one message and one message only */
-            $this->assertEquals(1, count($messages));
+            $this->assertCount(1, $messages);
 
             /* The streamed message to be parsed as if it was an individual PDU */
             $this->assertEquals(Message::parse($bytes), $messages[0]);


### PR DESCRIPTION
# Changed log

- According to the [official PHPUnit doc](https://phpunit.readthedocs.io/en/9.5/fixtures.html#more-setup-than-teardown), it should be the `protected function setUp` and `protected function tearDown` methods.
- Using the `assertCount` to assert expected count is same as result.