### PR TITLE
v0.5.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "rtckit/sip",
   "description": "Parser/Renderer for SIP protocol written in PHP",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "type": "library",
   "keywords": [
     "sip",

--- a/src/Header/AuthHeader.php
+++ b/src/Header/AuthHeader.php
@@ -159,11 +159,11 @@ class AuthHeader
                             break;
 
                         case 'nc':
-                            if (!ctype_digit($pv)) {
-                                throw new InvalidHeaderParameter('Invalid Auth header, non-integer nc parameter', Response::BAD_REQUEST);
+                            if (!ctype_xdigit($pv)) {
+                                throw new InvalidHeaderParameter('Invalid Auth header, non-hexadecimal nc parameter', Response::BAD_REQUEST);
                             }
 
-                            $val->nc = (int)$pv;
+                            $val->nc = $pv;
                             break;
 
                         case 'opaque':
@@ -245,7 +245,7 @@ class AuthHeader
                 }
 
                 if (isset($value->nc)) {
-                    $params[] = sprintf('ns=%08d', $value->nc);
+                    $params[] = sprintf('nc=%08s', $value->nc);
                 }
 
                 if (isset($value->opaque)) {

--- a/src/Header/AuthValue.php
+++ b/src/Header/AuthValue.php
@@ -44,8 +44,8 @@ class AuthValue
     /** @var string Quality of protection */
     public string $qop;
 
-    /** @var int Number once count */
-    public int $nc;
+    /** @var string Number once count */
+    public string $nc;
 
     /** @var string Server's opaque data blob */
     public string $opaque;

--- a/tests/Header/AuthHeaderTest.php
+++ b/tests/Header/AuthHeaderTest.php
@@ -100,7 +100,7 @@ class AuthHeaderTest extends TestCase
 
     public function testShouldParseVariousNcValueFormatting()
     {
-        $nc = 42;
+        $nc = hexdec('00000042');
 
         $auth = AuthHeader::parse([
             'Digest realm="sip.domain.net",qop="auth",nonce="7900f98e-3d80-4504-adbc-a61e5e040207",stale=FALSE,algorithm=MD5,nc=42',
@@ -114,7 +114,7 @@ class AuthHeaderTest extends TestCase
         $count = count($auth->values);
 
         for ($i = 0; $i < $count; $i++) {
-            $this->assertEquals($nc, $auth->values[$i]->nc);
+            $this->assertEquals($nc, hexdec($auth->values[$i]->nc));
         }
     }
 
@@ -170,7 +170,7 @@ class AuthHeaderTest extends TestCase
         $digest->values[0]->algorithm = 'MD5';
         $digest->values[0]->cnonce = '7900f98e';
         $digest->values[0]->qop = 'auth-int';
-        $digest->values[0]->nc = 42;
+        $digest->values[0]->nc = '42';
         $digest->values[0]->opaque = 'misc';
 
         $rendered = $digest->render('Authorization');
@@ -178,7 +178,7 @@ class AuthHeaderTest extends TestCase
         $this->assertNotNull($rendered);
         $this->assertIsString($rendered);
         $this->assertEquals(
-            'Authorization: Digest username="bob",realm="sip.domain.net",domain="sip:sip.domain.net",nonce="a61e5e040207",uri="sip:sip.domain.net",response="KJHAFgHFIUAG",stale=TRUE,algorithm="MD5",cnonce="7900f98e",qop="auth-int",ns=00000042,opaque="misc"' . "\r\n",
+            'Authorization: Digest username="bob",realm="sip.domain.net",domain="sip:sip.domain.net",nonce="a61e5e040207",uri="sip:sip.domain.net",response="KJHAFgHFIUAG",stale=TRUE,algorithm="MD5",cnonce="7900f98e",qop="auth-int",nc=00000042,opaque="misc"' . "\r\n",
             $rendered
         );
 
@@ -204,7 +204,7 @@ class AuthHeaderTest extends TestCase
         $this->assertNotNull($rendered);
         $this->assertIsString($rendered);
         $this->assertEquals(
-            'Authorization: Digest username="bob",realm="sip.domain.net",domain="sip:sip.domain.net",nonce="a61e5e040207",uri="sip:sip.domain.net",response="KJHAFgHFIUAG",stale=TRUE,algorithm="MD5",cnonce="7900f98e",qop="auth-int",ns=00000042,opaque="misc"' . "\r\n" .
+            'Authorization: Digest username="bob",realm="sip.domain.net",domain="sip:sip.domain.net",nonce="a61e5e040207",uri="sip:sip.domain.net",response="KJHAFgHFIUAG",stale=TRUE,algorithm="MD5",cnonce="7900f98e",qop="auth-int",nc=00000042,opaque="misc"' . "\r\n" .
             'Authorization: Basic MiScCreds' . "\r\n",
             $rendered
         );


### PR DESCRIPTION
Breaking changes:

* :lady_beetle: Fixed `nc` parameter rendering for Auth Header field values;
* :lady_beetle: Changed `nc` parameter to `string`; it must hold the verbatim value for digest hash verification.