### PR TITLE
v0.5.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "rtckit/sip",
   "description": "Parser/Renderer for SIP protocol written in PHP",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "type": "library",
   "keywords": [
     "sip",

--- a/src/Header/AuthHeader.php
+++ b/src/Header/AuthHeader.php
@@ -233,7 +233,7 @@ class AuthHeader
                 }
 
                 if (isset($value->algorithm)) {
-                    $params[] = "algorithm=\"{$value->algorithm}\"";
+                    $params[] = "algorithm={$value->algorithm}";
                 }
 
                 if (isset($value->cnonce)) {
@@ -245,7 +245,7 @@ class AuthHeader
                 }
 
                 if (isset($value->nc)) {
-                    $params[] = sprintf('nc=%08s', $value->nc);
+                    $params[] = "nc={$value->nc}";
                 }
 
                 if (isset($value->opaque)) {

--- a/tests/Header/AuthHeaderTest.php
+++ b/tests/Header/AuthHeaderTest.php
@@ -178,7 +178,7 @@ class AuthHeaderTest extends TestCase
         $this->assertNotNull($rendered);
         $this->assertIsString($rendered);
         $this->assertEquals(
-            'Authorization: Digest username="bob",realm="sip.domain.net",domain="sip:sip.domain.net",nonce="a61e5e040207",uri="sip:sip.domain.net",response="KJHAFgHFIUAG",stale=TRUE,algorithm="MD5",cnonce="7900f98e",qop="auth-int",nc=00000042,opaque="misc"' . "\r\n",
+            'Authorization: Digest username="bob",realm="sip.domain.net",domain="sip:sip.domain.net",nonce="a61e5e040207",uri="sip:sip.domain.net",response="KJHAFgHFIUAG",stale=TRUE,algorithm=MD5,cnonce="7900f98e",qop="auth-int",nc=42,opaque="misc"' . "\r\n",
             $rendered
         );
 
@@ -204,7 +204,7 @@ class AuthHeaderTest extends TestCase
         $this->assertNotNull($rendered);
         $this->assertIsString($rendered);
         $this->assertEquals(
-            'Authorization: Digest username="bob",realm="sip.domain.net",domain="sip:sip.domain.net",nonce="a61e5e040207",uri="sip:sip.domain.net",response="KJHAFgHFIUAG",stale=TRUE,algorithm="MD5",cnonce="7900f98e",qop="auth-int",nc=00000042,opaque="misc"' . "\r\n" .
+            'Authorization: Digest username="bob",realm="sip.domain.net",domain="sip:sip.domain.net",nonce="a61e5e040207",uri="sip:sip.domain.net",response="KJHAFgHFIUAG",stale=TRUE,algorithm=MD5,cnonce="7900f98e",qop="auth-int",nc=42,opaque="misc"' . "\r\n" .
             'Authorization: Basic MiScCreds' . "\r\n",
             $rendered
         );

--- a/tests/MessageTest.php
+++ b/tests/MessageTest.php
@@ -451,7 +451,7 @@ class MessageTest extends TestCase
             'Authorization: Digest username="bob",realm="atlanta.example.com",nonce="ea9c8e88df84f1cec4341ae6cbe5a359",uri="sips:ss2.biloxi.example.com",response="dfe56131d1958046689d83306477ecc",opaque=""' . "\r\n" .
             'Date: Thu, 21 Feb 2002 13:02:03 GMT' . "\r\n" .
             'Error-Info: <sip:screen-failure-term-ann@annoucement.example.com>' . "\r\n" .
-            'Proxy-Authenticate: Digest realm="atlanta.example.com",nonce="f84f1cec41e6cbe5aea9c8e88d359",stale=FALSE,algorithm="MD5",qop="auth",opaque=""' . "\r\n" .
+            'Proxy-Authenticate: Digest realm="atlanta.example.com",nonce="f84f1cec41e6cbe5aea9c8e88d359",stale=FALSE,algorithm=MD5,qop="auth",opaque=""' . "\r\n" .
             'Proxy-Authorization: Digest username="alice",realm="atlanta.example.com",nonce="wf84f1ceczx41ae6cbe5aea9c8e88d359",uri="sip:bob@biloxi.example.com",response="42ce3cef44b22f50c6a6071bc8",opaque=""' . "\r\n" .
             'Record-Route: <sip:ss2.biloxi.example.com;lr>' . "\r\n" .
             'MIME-Version: 1.0' . "\r\n" .
@@ -461,7 +461,7 @@ class MessageTest extends TestCase
             'Subject: Hello' . "\r\n" .
             'User-Agent: RTCKit\\SIP' . "\r\n" .
             'Warning: 301 isi.edu "Incompatible network address type \'E.164\'"' . "\r\n" .
-            'WWW-Authenticate: Digest realm="atlanta.example.com",nonce="84f1c1ae6cbe5ua9c8e88dfa3ecm3459",stale=FALSE,algorithm="MD5",qop="auth",opaque=""' . "\r\n" .
+            'WWW-Authenticate: Digest realm="atlanta.example.com",nonce="84f1c1ae6cbe5ua9c8e88dfa3ecm3459",stale=FALSE,algorithm=MD5,qop="auth",opaque=""' . "\r\n" .
             'X-Custom-Header: Something truly important' . "\r\n\r\n",
             $rendered
         );


### PR DESCRIPTION
:zap: Auth header value parameter rendering improvements:
* `nc` is being rendered verbatim (i.e. no implicit zero padding);
* `algorithm` is no longer rendered as quoted-string.